### PR TITLE
68: fixing issues showing charts using comma-serperated language

### DIFF
--- a/gview.php
+++ b/gview.php
@@ -262,12 +262,12 @@ if (!has_capability('mod/mootyper:viewgrades', context_module::instance($cm->id)
                              <td>'.$gr->fullhits.'</td>
                              <td>'.format_float($gr->precisionfield).'%</td>
                              <td>'.date(get_config('mod_mootyper', 'dateformat'), $gr->timetaken).'</td>
-                             <td>'.$gr->wpm.'</td>
+                             <td>'.format_float($gr->wpm).'</td>
                              <td>'.$removelnk.'</td></tr>';
                 // Get information to draw the chart for all exercises in this lesson.
                 $labels[] = $gr->firstname.' '.$gr->lastname.' Ex-'.$gr->exercisename;  // This gets the exercise number.
-                $serieshitsperminute[] = format_float($gr->hitsperminute); // Get the hits per minute value.
-                $seriesprecision[] = format_float($gr->precisionfield);  // Get the precision percentage value.
+                $serieshitsperminute[] = $gr->hitsperminute; // Get the hits per minute value.
+                $seriesprecision[] = $gr->precisionfield;  // Get the precision percentage value.
                 $serieswpm[] = $gr->wpm; // Get the corrected words per minute rate.
             }
             $avg = get_grades_avg($grds);

--- a/owngrades.php
+++ b/owngrades.php
@@ -151,10 +151,10 @@ if (!has_capability('mod/mootyper:viewmygrades', context_module::instance($cm->i
                         .'</td><td>'.format_float($gr->hitsperminute).'</td><td>'.$gr->fullhits
                         .'</td><td>'.format_float($gr->precisionfield).'%</td><td>'
                         .date(get_config('mod_mootyper', 'dateformat'), $gr->timetaken)
-                        .'</td><td>'.$gr->wpm.'</td><td>'.$removelnk.'</td></tr>';
+                        .'</td><td>'.format_float($gr->wpm).'</td><td>'.$removelnk.'</td></tr>';
             $labels[] = 'Ex-'.$fcol;  // This gets the exercise number.
-            $serieshitsperminute[] = format_float($gr->hitsperminute); // Get the hits per minute value.
-            $seriesprecision[] = format_float($gr->precisionfield);  // Get the precision percentage value.
+            $serieshitsperminute[] = $gr->hitsperminute; // Get the hits per minute value.
+            $seriesprecision[] = $gr->precisionfield;  // Get the precision percentage value.
             $serieswpm[] = $gr->wpm; // Get the corrected words per minute rate.
         }
         $avg = get_grades_avg($grds);


### PR DESCRIPTION
Hi drachels,

due to my changes, the variables are no longer converted to comma-seperated notation with format_float. As a result, the charts are displayed correctly. Only hovering over the charts still shows point-seperated notation. But this needs deeper changings in moodle chart api, I think!

When displaying the results in the tables, I added the transformation to a variable. Now all variables should be displayed correctly, according to the language you've chosen.